### PR TITLE
Initial commit.  Returns email functionality that was removed.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,7 +35,7 @@ class Admin::UsersController < Admin::BaseController
           @agency_user_relationship.creator = current_user.id
           
           if @agency_user_relationship.save
-            UserMailer.agency_helping_email(@agency_user_relationship.user.email, @agency_user_relationship.user.email, current_user.agency).deliver
+            UserMailer.agency_helping_email(@agency_user_relationship.user.email, @agency_user_relationship.agency.email || @agency_user_relationship.agency.name, current_user.agency).deliver
           end
         end
         flash[:notice] = t(:user_created)
@@ -142,7 +142,7 @@ class Admin::UsersController < Admin::BaseController
       #now that we have the relationship object, set it as active/confirmed
       rel.update_attributes(relationship_status: RelationshipStatus.confirmed)
       agency = Agency.find(id)
-      UserMailer.agency_helping_email(@user.email, agency.email, agency)
+      UserMailer.agency_helping_email(@user.email, agency.email || agency.name, agency).deliver
     end
     revoked_agencies.each do |revoked_id|
       revoked = AgencyUserRelationship.find_by(agency_id: revoked_id, user_id: @user.id)
@@ -160,6 +160,7 @@ class Admin::UsersController < Admin::BaseController
     new_buddies.each do |id|
       rel = UserRelationship.find_or_create_by!( traveler: @user, delegate: User.find(id)) do |ur|
         ur.update_attributes(relationship_status: RelationshipStatus.confirmed)
+        UserMailer.buddy_request_email(ur.traveler.email, ur.delegate.email).deliver
       end
       rel.update_attributes(relationship_status: RelationshipStatus.confirmed)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ private
       #now that we have the relationship object, set it as active/confirmed
       rel.update_attributes(relationship_status: RelationshipStatus.confirmed)
       agency = Agency.find(id)
-      UserMailer.agency_helping_email(@user.email, agency.email, agency)
+      UserMailer.agency_helping_email(@user.email, agency.email || agency.name, agency).deliver
     end
     revoked_agencies.each do |revoked_id|
       revoked = AgencyUserRelationship.find_by(agency_id: revoked_id, user_id: @user.id)
@@ -94,6 +94,7 @@ private
     new_buddies.each do |id|
       rel = UserRelationship.find_or_create_by!( traveler: @user, delegate: User.find(id)) do |ur|
         ur.update_attributes(relationship_status: RelationshipStatus.confirmed)
+        UserMailer.buddy_request_email(ur.traveler.email, ur.delegate.email).deliver
       end
       rel.update_attributes(relationship_status: RelationshipStatus.confirmed)
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -63,8 +63,8 @@ class UserMailer < ActionMailer::Base
     @to_email = to_email
     @from_email = from_email
     
-    # TODO localize
-    mail(to: @to_email, subject: t(:one_click_buddy_revoke_from_from_email, by: @from_email))
+    # TODO localize #TODO Is this set up backwards?  i.e. text is saying that the traveler is the delegate?
+    mail(to: @to_email, subject: t(:one_click_buddy_revoke_from_from_email, by: @from_email), from: from_email)
   end
 
   def traveler_confirmation_email(to_email, from_email)


### PR DESCRIPTION
As part of the process of bringing the user controllers (admin vs base) inline, email functionality was taken out/never added and hasn't been working.  This PR is to add it back, specifically when adding an agency or a delegate to a user.  Functional testing seems solid, but no new rspec tests.

Issues
1. Emails are sent only on creation of relationships, rather than update or confirmation.  This is just because that's the *simplest*, rather than *best* way of doing this.
2. Agency-based emails come from either the agency's public email address or, if that is not set, their name.  Since we don't validate that agencies must have a public contact email, we can't just use that.  Users must have an email address, so that will always be used in emails.
3. During testing, it appeared that buddy emails were going to the traveler, rather than the delegate.  Unsure whether that's just the header saying the wrong thing or if the emails are actually going to the wrong place.